### PR TITLE
[IMP] connector_five9: Remove project_task_category

### DIFF
--- a/connector_five9/__manifest__.py
+++ b/connector_five9/__manifest__.py
@@ -22,7 +22,6 @@
         "sales_team",
         "partner_firstname",
         "project",
-        "project_task_category",
         "queue_job",
     ],
     "data": [


### PR DESCRIPTION
* Remove dependency that was already worked around

I grepped for `categ_id`, and the only time it exists in this code is in a mapper docblock.